### PR TITLE
Remove SSL CA directive from Ruby and Rails examples

### DIFF
--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem "mysql2"
+gem "mysql2", ">= 0.5.4"

--- a/ruby/mysql.rb
+++ b/ruby/mysql.rb
@@ -5,8 +5,7 @@ client = Mysql2::Client.new(
   username: "[USERNAME]",
   password: "[PASSWORD]",
   database: "[DATABASE]",
-  ssl_mode: :verify_identity,
-  sslca:    "/etc/ssl/certs/ca-certificates.crt"
+  ssl_mode: :verify_identity
 )
 
 puts "Successfully connected to PlanetScale!"

--- a/ruby/rails/database.yml
+++ b/ruby/rails/database.yml
@@ -6,4 +6,3 @@ production:
   password: [PASSWORD]
   host: [HOSTNAME]
   ssl_mode: verify_identity
-  sslca: "/etc/ssl/cert.pem"


### PR DESCRIPTION
We should be able to remove `ssl_mode`/`sslca` from the Ruby and Rails examples. mysql2 [version 0.5.4](https://github.com/brianmario/mysql2/releases/tag/0.5.4) was released in May and handles finding the correct CA path now.

Local testing was successful.