### PR TITLE
Check links every 24 hours

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -4,7 +4,7 @@ on:
   repository_dispatch:
   workflow_dispatch:
   schedule:
-    - cron: "00 06 * * *"
+    - cron: "0 6 * * *"
 
 jobs:
   linkChecker:

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,27 @@
+name: Links
+
+on:
+  repository_dispatch:
+  workflow_dispatch:
+  schedule:
+    - cron: "00 06 * * *"
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v1.5.0
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Create Issue From File
+        if: steps.lychee.outputs.exit_code != 0
+        uses: peter-evans/create-issue-from-file@v3
+        with:
+          title: Link Checker Report
+          content-filepath: ./lychee/out.md
+          labels: report, automated issue

--- a/README.md
+++ b/README.md
@@ -56,3 +56,5 @@ happy to help!
 ## License
 
 See [LICENSE](LICENSE)
+
+[![Check Links](https://github.com/planetscale/connection-examples/actions/workflows/links.yml/badge.svg)](https://github.com/planetscale/connection-examples/actions/workflows/links.yml)


### PR DESCRIPTION
This PR adds a GitHub Action that checks all links in HTML, Markdown and .txt files in this repository every 24 hours.