### PR TITLE
Add a TypeORM mysql example

### DIFF
--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -30,6 +30,11 @@ If you're just connecting a Node application, proceed with Option 1. If you're u
 1. Open your `schema.prisma` file and replace `datasource db {}` with the code in our [`schema.prisma` example file](https://github.com/planetscale/connection-examples/blob/main/nodejs/prisma/schema.prisma).
 2. Replace the placeholders for `HOSTNAME`, `DATABASE`, `USERNAME`, and `PASSWORD` with the copied values. We encourage you to move these placeholder values into your `.env` file.
 
+### Option 3: TypeORM
+
+1. TypeORM supports both the `mysql` and `mysql2` drivers. Open `src/data-source.ts` or your equivalent add a DataSource using the configuration in our [example](typeorm/data-source.ts).
+2. Replace the placeholders for `HOSTNAME`, `DATABASE`, `USERNAME`, and `PASSWORD` with the copied values from the previous section. We encourage you to move these placeholder values into your `.env` file.
+
 ## More resources
 
 **Express resources**

--- a/nodejs/typeorm/data-source.ts
+++ b/nodejs/typeorm/data-source.ts
@@ -1,0 +1,13 @@
+import { DataSource } from "typeorm"
+
+export const AppDataSource = new DataSource({
+    type: "mysql",
+    host: "[HOSTNAME]",
+    port: 3306,
+    username: "[USERNAME]",
+    password: "[PASSWORD]",
+    database: "[DATABASE]",
+    ssl: {
+        rejectUnauthorized: true
+    }
+})


### PR DESCRIPTION
TypeORM uses the `mysql` or `mysql2` driver, so the options are basically the same, but we still get the odd question about TypeORM specifically.

This adds an example config you can paste into the sample app generated by `typeorm init --name MyProject --database mysql` to get a secure connection.

https://typeorm.io/data-source-options#mysql--mariadb-data-source-options