### PR TITLE
docs(readme): clarify Vitess/MySQL vs Postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Example client implementations to connect to PlanetScale
 
+> **Note:** These examples target [PlanetScale Vitess](https://vitess.io/) / MySQL-compatible databases and MySQL client libraries. PlanetScale also offers managed PostgreSQL; connect to Postgres databases with PostgreSQL clients and connection strings. For more information and examples, see the [PlanetScale Postgres documentation](https://planetscale.com/docs/postgres).
+
 This repository contains small example applications that connect to
 PlanetScale in different languages and frameworks.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Example client implementations to connect to PlanetScale
 
-> **Note:** These examples target [PlanetScale Vitess](https://vitess.io/) / MySQL-compatible databases and MySQL client libraries. PlanetScale also offers managed PostgreSQL; connect to Postgres databases with PostgreSQL clients and connection strings. For more information and examples, see the [PlanetScale Postgres documentation](https://planetscale.com/docs/postgres).
+> **Note:** These examples target PlanetScale Vitess/MySQL. PlanetScale also offers managed PostgreSQL. For more information, see the [PlanetScale Postgres documentation](https://planetscale.com/docs/postgres).
 
 This repository contains small example applications that connect to
 PlanetScale in different languages and frameworks.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Example client implementations to connect to PlanetScale
 
-> **Note:** These examples target PlanetScale Vitess/MySQL. PlanetScale also offers managed PostgreSQL. For more information, see the [PlanetScale Postgres documentation](https://planetscale.com/docs/postgres).
+> **Note:** These examples target PlanetScale Vitess/MySQL. PlanetScale also offers managed Postgres. For more information, see the [PlanetScale Postgres documentation](https://planetscale.com/docs/postgres).
 
 This repository contains small example applications that connect to
 PlanetScale in different languages and frameworks.


### PR DESCRIPTION
## Summary

- README: clarify that this repository targets PlanetScale Vitess/MySQL (or the MySQL tooling shown in the repo), not PlanetScale-only-MySQL.
- Link readers to Postgres documentation at https://planetscale.com/docs/postgres for managed PostgreSQL databases.

PlanetScale offers both MySQL-compatible (Vitess) and PostgreSQL products.

Made with [Cursor](https://cursor.com)